### PR TITLE
AESCrypt should inherit from NSObject, even if only contains static methods

### DIFF
--- a/AESCrypt.h
+++ b/AESCrypt.h
@@ -29,7 +29,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface AESCrypt
+@interface AESCrypt : NSObject
 
 + (NSString *)encrypt:(NSString *)message password:(NSString *)password;
 + (NSString *)decrypt:(NSString *)base64EncodedString password:(NSString *)password;


### PR DESCRIPTION
was crashing in iOS 4.3 without it
