### PR TITLE
Add preliminary AESCrypt.podspec file

### DIFF
--- a/AESCrypt.podspec
+++ b/AESCrypt.podspec
@@ -1,0 +1,10 @@
+Pod::Spec.new do |s|
+  s.name         = "AESCrypt"
+  s.version      = "0.0.1"
+  s.summary      = "Simple AES encryption / decryption for iOS and OS X."
+  s.homepage     = "https://github.com/Gurpartap/AESCrypt-ObjC"
+  s.license      = 'MIT'
+  s.author       = { "Gurpartap Singh" => "contact@gurpartap.com" }
+  s.source       = { :git => "https://github.com/Gurpartap/AESCrypt-ObjC.git", :commit => "6fa7a4f95d3cb5ada117e8a96b7a9eacaf0457ae" }
+  s.source_files = '*.{h,m}'
+end


### PR DESCRIPTION
Hi Gurpartap
I recently used `AESCrypt` on a personal project and I'm using [CocoaPods](http://cocoapods.org/) for managing dependencies.

I created an `AESCrypt.podspec` file if you're interested in getting `AESCrypt` into CocoaPods and maintaing it in your repo.

If you don't mind I'd also like to submit the podspec to https://github.com/CocoaPods/Specs.
#### Notes
- CocoaPods suggest that a library should be versioned. `0.0.1` is acceptable for a first submission. But it's preferred that you choose a version number and tag it in the repo.
  - If you do, then `:tag => 'tagname'` should be used instead of `:commit => 'commitsha'` in the podspec
  - See https://github.com/CocoaPods/Specs/wiki/%22Please-add-semantic-version-tags%22-issue-template if you're interested
