### PR TITLE
fix the condition if keydata's length is 16 or 24

### DIFF
--- a/NSData+CommonCrypto.m
+++ b/NSData+CommonCrypto.m
@@ -282,11 +282,11 @@ static void FixKeyLengths( CCAlgorithm algorithm, NSMutableData * keyData, NSMut
 	{
 		case kCCAlgorithmAES128:
 		{
-			if ( keyLength < 16 )
+			if ( keyLength <= 16 )
 			{
 				[keyData setLength: 16];
 			}
-			else if ( keyLength < 24 )
+			else if ( keyLength <= 24 )
 			{
 				[keyData setLength: 24];
 			}


### PR DESCRIPTION
Method:FixKeyLengths
case:kCCAlgorithmAES128, fix the condition if keydata's length is 16 or 24
